### PR TITLE
Convert plugin configurations to lazy.vim

### DIFF
--- a/nvim/.config/nvim/lua/npx/auto-complete.lua
+++ b/nvim/.config/nvim/lua/npx/auto-complete.lua
@@ -1,37 +1,48 @@
-local cmp = require("cmp")
+return {
+    "hrsh7th/nvim-cmp",
+    dependencies = {
+        "hrsh7th/cmp-nvim-lsp",
+        "hrsh7th/cmp-buffer",
+        "hrsh7th/cmp-vsnip",
+        "hrsh7th/vim-vsnip",
+    },
+    config = function()
+        local cmp = require("cmp")
 
-cmp.setup({
-    snippet = {
-        expand = function(args)
-            -- For `vsnip` user.
-            vim.fn["vsnip#anonymous"](args.body)
-        end
-    },
-    mapping = {
-        ["<Tab>"] = cmp.mapping.select_next_item({
-            behavior = cmp.SelectBehavior.Replace
-        }),
-        ["<Down>"] = cmp.mapping.select_next_item({
-            behavior = cmp.SelectBehavior.Select
-        }),
-        ["<Up>"] = cmp.mapping.select_prev_item({
-            behavior = cmp.SelectBehavior.Select
-        }),
-        ["<C-d>"] = cmp.mapping.scroll_docs(-4),
-        ["<C-f>"] = cmp.mapping.scroll_docs(4),
-        ["<C-e>"] = cmp.mapping.close(),
-        ["<CR>"] = cmp.mapping.confirm({
-            behavior = cmp.ConfirmBehavior.Insert,
-            select = true
+        cmp.setup({
+            snippet = {
+                expand = function(args)
+                    -- For `vsnip` user.
+                    vim.fn["vsnip#anonymous"](args.body)
+                end
+            },
+            mapping = {
+                ["<Tab>"] = cmp.mapping.select_next_item({
+                    behavior = cmp.SelectBehavior.Replace
+                }),
+                ["<Down>"] = cmp.mapping.select_next_item({
+                    behavior = cmp.SelectBehavior.Select
+                }),
+                ["<Up>"] = cmp.mapping.select_prev_item({
+                    behavior = cmp.SelectBehavior.Select
+                }),
+                ["<C-d>"] = cmp.mapping.scroll_docs(-4),
+                ["<C-f>"] = cmp.mapping.scroll_docs(4),
+                ["<C-e>"] = cmp.mapping.close(),
+                ["<CR>"] = cmp.mapping.confirm({
+                    behavior = cmp.ConfirmBehavior.Insert,
+                    select = true
+                })
+            },
+            sources = {
+                {name = "nvim_lsp", max_item_count = 10},
+                {name = "vsnip", max_item_count = 10},
+                {name = "buffer", keyword_length = 5, max_item_count = 10}
+            },
+            window = {
+                completion = {border = "rounded", scrollbar = "║"},
+                documentation = {border = "rounded", scrollbar = ""}
+            }
         })
-    },
-    sources = {
-        {name = "nvim_lsp", max_item_count = 10},
-        {name = "vsnip", max_item_count = 10},
-        {name = "buffer", keyword_length = 5, max_item_count = 10}
-    },
-    window = {
-        completion = {border = "rounded", scrollbar = "║"},
-        documentation = {border = "rounded", scrollbar = ""}
-    }
-})
+    end
+}

--- a/nvim/.config/nvim/lua/npx/buffer-management.lua
+++ b/nvim/.config/nvim/lua/npx/buffer-management.lua
@@ -1,132 +1,135 @@
--- Const
-local BUF_TRACKED = 'npx_tracked'
-
--- Util
-local cmd = function(cmd) return function() vim.cmd(cmd); end end
-
-local id = vim.api.nvim_create_augroup("npx_buffer_management", {clear = true})
-
-local autocmd = function(events, callback)
-    vim.api.nvim_create_autocmd(events, {
-        group = id,
-        pattern = {"*"},
-        callback = callback
-    })
-end
-
--- Tracking Buffers
-local function track(buf) vim.api.nvim_buf_set_var(buf, BUF_TRACKED, true) end
-
-local function untrack(buf)
-    local delete_tracked = function()
-        vim.api.nvim_buf_del_var(buf, BUF_TRACKED)
-    end
-    pcall(delete_tracked)
-end
-
-local function is_tracked(buf)
-    local read_tracked = function()
-        vim.api.nvim_buf_get_var(buf, BUF_TRACKED)
-    end
-    return pcall(read_tracked)
-end
-
-local function get_tracked_buffers()
-    return vim.tbl_filter(function(buf)
-        local listed = vim.api.nvim_buf_get_option(buf, "buflisted")
-        local tracked = is_tracked(buf)
-        return listed and tracked
-    end, vim.api.nvim_list_bufs())
-end
-
--- Mark for kill
-local kill_buffer = nil
-
-local mark_for_kill = function(buf) kill_buffer = buf end
-
-local kill = function()
-    if kill_buffer == nil then return end
-
-    vim.api.nvim_buf_delete(kill_buffer, {})
-    kill_buffer = nil
-end
-
-local should_kill = function(buf)
-    local hasName = vim.api.nvim_buf_get_name(buf) ~= ""
-    local listed = vim.api.nvim_buf_get_option(buf, "buflisted")
-    local modified = vim.api.nvim_buf_get_option(buf, "modified")
-    local tracked = is_tracked(buf)
-
-    return listed and hasName and not modified and not tracked
-end
-
--- Goto
-local function goto_nth_tracked(n)
-    return function()
-        local tracked_buffers = get_tracked_buffers()
-        local buf = tracked_buffers[n]
-        if (buf ~= nil) then cmd("b " .. buf)() end
-    end
-end
-
--- Autocommands
--- autocmd({"BufWritePost"}, function() track(0) end)
-
--- Keymap: ALT+JKL
-vim.keymap.set('n', '∆', goto_nth_tracked(1),
-               {desc = 'Activate Tracked Buffer J'})
-vim.keymap.set('n', '˚', goto_nth_tracked(2),
-               {desc = 'Activate Tracked Buffer K'})
-vim.keymap.set('n', '¬', goto_nth_tracked(3),
-               {desc = 'Activate Tracked Buffer L'})
-
--- TODO telescope picker for tracked buffers
--- TODO binding to close all untracked
--- TODO heuristic which buffers to keep
-
-local COLORS = {
-    key = "%#lualine_transitional_lualine_a_normal_to_lualine_b_inactive#",
-    key_active = "%#lualine_transitional_lualine_a_normal_to_lualine_b_normal#",
-    hl = "%#lualine_b_normal#",
-    bg = "%#lualine_b_inactive#"
-}
-
-local function tracked_buffers_lualine()
-    local tracked_buffers = get_tracked_buffers()
-
-    local trimmed = {unpack(tracked_buffers, 1, 3)}
-    local index_mapping = {'j', 'k', 'l'}
-
-    local pretty = ""
-    for index, buf in pairs(trimmed) do
-        local bufname = vim.api.nvim_buf_get_name(buf)
-        if bufname == "" then bufname = "No Name" end
-        local name = vim.fn.fnamemodify(bufname, ":t")
-
-        local is_current = vim.api.nvim_get_current_buf() == buf
-        local is_modified = vim.api.nvim_buf_get_option(buf, "modified")
-
-        local key = is_current and COLORS.key_active or COLORS.key
-        key = key .. " " .. index_mapping[index] .. ": " .. COLORS.bg
-
-        local mod = is_modified and "" or " "
-        local display = name .. mod
-        if is_current then display = COLORS.hl .. display .. COLORS.bg end
-
-        pretty = pretty .. key .. display
-    end
-
-    return "%#lualine_b_inactive#" .. pretty
-end
-
-vim.keymap.set('n', 'Q',
-               function() print(vim.inspect(tracked_buffers_lualine())) end)
-
--- Module
 return {
-    tracked_buffers_lualine = tracked_buffers_lualine,
-    track = track,
-    untrack = untrack,
-    is_tracked = is_tracked
-}
+    config = function()
+        -- Const
+        local BUF_TRACKED = 'npx_tracked'
 
+        -- Util
+        local cmd = function(cmd) return function() vim.cmd(cmd); end end
+
+        local id = vim.api.nvim_create_augroup("npx_buffer_management", {clear = true})
+
+        local autocmd = function(events, callback)
+            vim.api.nvim_create_autocmd(events, {
+                group = id,
+                pattern = {"*"},
+                callback = callback
+            })
+        end
+
+        -- Tracking Buffers
+        local function track(buf) vim.api.nvim_buf_set_var(buf, BUF_TRACKED, true) end
+
+        local function untrack(buf)
+            local delete_tracked = function()
+                vim.api.nvim_buf_del_var(buf, BUF_TRACKED)
+            end
+            pcall(delete_tracked)
+        end
+
+        local function is_tracked(buf)
+            local read_tracked = function()
+                vim.api.nvim_buf_get_var(buf, BUF_TRACKED)
+            end
+            return pcall(read_tracked)
+        end
+
+        local function get_tracked_buffers()
+            return vim.tbl_filter(function(buf)
+                local listed = vim.api.nvim_buf_get_option(buf, "buflisted")
+                local tracked = is_tracked(buf)
+                return listed and tracked
+            end, vim.api.nvim_list_bufs())
+        end
+
+        -- Mark for kill
+        local kill_buffer = nil
+
+        local mark_for_kill = function(buf) kill_buffer = buf end
+
+        local kill = function()
+            if kill_buffer == nil then return end
+
+            vim.api.nvim_buf_delete(kill_buffer, {})
+            kill_buffer = nil
+        end
+
+        local should_kill = function(buf)
+            local hasName = vim.api.nvim_buf_get_name(buf) ~= ""
+            local listed = vim.api.nvim_buf_get_option(buf, "buflisted")
+            local modified = vim.api.nvim_buf_get_option(buf, "modified")
+            local tracked = is_tracked(buf)
+
+            return listed and hasName and not modified and not tracked
+        end
+
+        -- Goto
+        local function goto_nth_tracked(n)
+            return function()
+                local tracked_buffers = get_tracked_buffers()
+                local buf = tracked_buffers[n]
+                if (buf ~= nil) then cmd("b " .. buf)() end
+            end
+        end
+
+        -- Autocommands
+        -- autocmd({"BufWritePost"}, function() track(0) end)
+
+        -- Keymap: ALT+JKL
+        vim.keymap.set('n', '∆', goto_nth_tracked(1),
+                    {desc = 'Activate Tracked Buffer J'})
+        vim.keymap.set('n', '˚', goto_nth_tracked(2),
+                    {desc = 'Activate Tracked Buffer K'})
+        vim.keymap.set('n', '¬', goto_nth_tracked(3),
+                    {desc = 'Activate Tracked Buffer L'})
+
+        -- TODO telescope picker for tracked buffers
+        -- TODO binding to close all untracked
+        -- TODO heuristic which buffers to keep
+
+        local COLORS = {
+            key = "%#lualine_transitional_lualine_a_normal_to_lualine_b_inactive#",
+            key_active = "%#lualine_transitional_lualine_a_normal_to_lualine_b_normal#",
+            hl = "%#lualine_b_normal#",
+            bg = "%#lualine_b_inactive#"
+        }
+
+        local function tracked_buffers_lualine()
+            local tracked_buffers = get_tracked_buffers()
+
+            local trimmed = {unpack(tracked_buffers, 1, 3)}
+            local index_mapping = {'j', 'k', 'l'}
+
+            local pretty = ""
+            for index, buf in pairs(trimmed) do
+                local bufname = vim.api.nvim_buf_get_name(buf)
+                if bufname == "" then bufname = "No Name" end
+                local name = vim.fn.fnamemodify(bufname, ":t")
+
+                local is_current = vim.api.nvim_get_current_buf() == buf
+                local is_modified = vim.api.nvim_buf_get_option(buf, "modified")
+
+                local key = is_current and COLORS.key_active or COLORS.key
+                key = key .. " " .. index_mapping[index] .. COLORS.bg
+
+                local mod = is_modified and "" or " "
+                local display = name .. mod
+                if is_current then display = COLORS.hl .. display .. COLORS.bg end
+
+                pretty = pretty .. key .. display
+            end
+
+            return "%#lualine_b_inactive#" .. pretty
+        end
+
+        vim.keymap.set('n', 'Q',
+                    function() print(vim.inspect(tracked_buffers_lualine())) end)
+
+        -- Module
+        return {
+            tracked_buffers_lualine = tracked_buffers_lualine,
+            track = track,
+            untrack = untrack,
+            is_tracked = is_tracked
+        }
+    end
+}

--- a/nvim/.config/nvim/lua/npx/chatgpt.lua
+++ b/nvim/.config/nvim/lua/npx/chatgpt.lua
@@ -1,42 +1,47 @@
-require("gp").setup({
-    openai_api_key = {"cat", "~/.gpt4"},
-    agents = {
-        {
-            name = "ChatGPT4",
-            chat = true,
-            command = false,
-            -- string with model name or table with model name and parameters
-            model = {model = "gpt-4-1106-preview", temperature = 1.1, top_p = 1},
-            -- system prompt (use this to specify the persona/role of the AI)
-            system_prompt = "You are a general AI assistant.\n\n" ..
-                "The user provided the additional info about how they would like you to respond:\n\n" ..
-                "- If you're unsure don't guess and say you don't know instead.\n" ..
-                "- Ask question if you need clarification to provide better answer.\n" ..
-                "- Think deeply and carefully from first principles step by step.\n" ..
-                "- Zoom out first to see the big picture and then zoom in to details.\n" ..
-                "- Use Socratic method to improve your thinking and coding skills.\n" ..
-                "- Don't elide any code from your output if the answer requires coding.\n" ..
-                "- Take a deep breath; You've got this!\n"
-        }, {
-            name = "RefactorTS",
-            chat = false,
-            command = true,
-            -- string with model name or table with model name and parameters
-            model = {model = "gpt-4-turbo", temperature = 0.1, top_p = 1},
-            -- system prompt (use this to specify the persona/role of the AI)
-            system_prompt = "You are an experienced senior TypeScript developer.\n\n" ..
-                "Your job is to carefully follow the given instructions to refactor TypeScript code.\n" ..
-                "Output code only and do not speak directly to me, omitting any additional text or instructions.\n"
-        }, {
-            name = "CodeGPT4",
-            chat = false,
-            command = true,
-            -- string with model name or table with model name and parameters
-            model = {model = "gpt-4-1106-preview", temperature = 0.8, top_p = 1},
-            -- system prompt (use this to specify the persona/role of the AI)
-            system_prompt = "You are an AI working as a code editor.\n\n" ..
-                "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n" ..
-                "START AND END YOUR ANSWER WITH:\n\n```"
-        }
-    }
-})
+return {
+    "robitx/gp.nvim",
+    config = function()
+        require("gp").setup({
+            openai_api_key = {"cat", "~/.gpt4"},
+            agents = {
+                {
+                    name = "ChatGPT4",
+                    chat = true,
+                    command = false,
+                    -- string with model name or table with model name and parameters
+                    model = {model = "gpt-4-1106-preview", temperature = 1.1, top_p = 1},
+                    -- system prompt (use this to specify the persona/role of the AI)
+                    system_prompt = "You are a general AI assistant.\n\n" ..
+                        "The user provided the additional info about how they would like you to respond:\n\n" ..
+                        "- If you're unsure don't guess and say you don't know instead.\n" ..
+                        "- Ask question if you need clarification to provide better answer.\n" ..
+                        "- Think deeply and carefully from first principles step by step.\n" ..
+                        "- Zoom out first to see the big picture and then zoom in to details.\n" ..
+                        "- Use Socratic method to improve your thinking and coding skills.\n" ..
+                        "- Don't elide any code from your output if the answer requires coding.\n" ..
+                        "- Take a deep breath; You've got this!\n"
+                }, {
+                    name = "RefactorTS",
+                    chat = false,
+                    command = true,
+                    -- string with model name or table with model name and parameters
+                    model = {model = "gpt-4-turbo", temperature = 0.1, top_p = 1},
+                    -- system prompt (use this to specify the persona/role of the AI)
+                    system_prompt = "You are an experienced senior TypeScript developer.\n\n" ..
+                        "Your job is to carefully follow the given instructions to refactor TypeScript code.\n" ..
+                        "Output code only and do not speak directly to me, omitting any additional text or instructions.\n"
+                }, {
+                    name = "CodeGPT4",
+                    chat = false,
+                    command = true,
+                    -- string with model name or table with model name and parameters
+                    model = {model = "gpt-4-1106-preview", temperature = 0.8, top_p = 1},
+                    -- system prompt (use this to specify the persona/role of the AI)
+                    system_prompt = "You are an AI working as a code editor.\n\n" ..
+                        "Please AVOID COMMENTARY OUTSIDE OF THE SNIPPET RESPONSE.\n" ..
+                        "START AND END YOUR ANSWER WITH:\n\n```"
+                }
+            }
+        })
+    end
+}

--- a/nvim/.config/nvim/lua/npx/comment.lua
+++ b/nvim/.config/nvim/lua/npx/comment.lua
@@ -1,1 +1,6 @@
-require('Comment').setup()
+return {
+    "numToStr/Comment.nvim",
+    config = function()
+        require('Comment').setup()
+    end
+}

--- a/nvim/.config/nvim/lua/npx/fterm.lua
+++ b/nvim/.config/nvim/lua/npx/fterm.lua
@@ -1,13 +1,18 @@
-local fterm = require("FTerm")
+return {
+    "numToStr/FTerm.nvim",
+    config = function()
+        local fterm = require("FTerm")
 
-fterm.setup({
-	border = "rounded",
-	dimensions = {
-		height = 0.7,
-		width = 0.6,
-	},
-})
+        fterm.setup({
+            border = "rounded",
+            dimensions = {
+                height = 0.7,
+                width = 0.6,
+            },
+        })
 
--- alt-p
-vim.keymap.set("n", "π", fterm.toggle)
-vim.keymap.set("t", "π", '<C-\\><C-n><CMD>lua require("FTerm").toggle()<CR>')
+        -- alt-p
+        vim.keymap.set("n", "π", fterm.toggle)
+        vim.keymap.set("t", "π", '<C-\\><C-n><CMD>lua require("FTerm").toggle()<CR>')
+    end
+}

--- a/nvim/.config/nvim/lua/npx/init.lua
+++ b/nvim/.config/nvim/lua/npx/init.lua
@@ -1,17 +1,7 @@
 -- Set leader before other plugins
 vim.g.mapleader = ' ';
 
-require("npx.auto-complete")
-require("npx.buffer-management")
-require("npx.chatgpt")
-require("npx.comment")
-require("npx.fterm")
-require("npx.lsp")
-require("npx.statusline")
-require("npx.surround")
-require("npx.telescope")
-require("npx.treesitter")
-require("npx.which-key")
+require("npx.lazyvim")
 
 -- Setup Autopairs
 require("nvim-autopairs").setup()

--- a/nvim/.config/nvim/lua/npx/lazyvim.lua
+++ b/nvim/.config/nvim/lua/npx/lazyvim.lua
@@ -127,4 +127,37 @@ return {
   {
     "alvan/vim-closetag",
   },
+
+  -- Add configuration for `cmp` plugin
+  require("npx.auto-complete"),
+
+  -- Add configuration for `buffer-management`
+  require("npx.buffer-management"),
+
+  -- Add configuration for `gp` plugin
+  require("npx.chatgpt"),
+
+  -- Add configuration for `Comment` plugin
+  require("npx.comment"),
+
+  -- Add configuration for `FTerm` plugin
+  require("npx.fterm"),
+
+  -- Add configuration for `lsp` plugin
+  require("npx.lsp"),
+
+  -- Add configuration for `lualine` plugin
+  require("npx.statusline"),
+
+  -- Add configuration for `nvim-surround` plugin
+  require("npx.surround"),
+
+  -- Add configuration for `telescope` plugin
+  require("npx.telescope"),
+
+  -- Add configuration for `nvim-treesitter` plugin
+  require("npx.treesitter"),
+
+  -- Add configuration for `which-key` plugin
+  require("npx.which-key"),
 }

--- a/nvim/.config/nvim/lua/npx/lsp.lua
+++ b/nvim/.config/nvim/lua/npx/lsp.lua
@@ -1,135 +1,144 @@
-local mason = require("npx.mason-setup")
-
-mason.configure("pylsp", {
-    settings = {
-        pylsp = {
-            plugins = {
-                pycodestyle = {ignore = {}, maxLineLength = 100},
-                rope_autoimport = {enabled = true},
-                rope_completion = {enabled = true}
-            }
-        }
-    }
-})
-
--- borders for hover
-vim.lsp.handlers["textDocument/hover"] =
-    vim.lsp.with(vim.lsp.handlers.hover, {border = "rounded"})
-
--- ESLint
-mason.configure("eslint", {
-    filetypes = {
-        'javascript', 'javascriptreact', 'javascript.jsx', 'typescript',
-        'typescriptreact', 'typescript.tsx', 'vue', 'svelte', 'astro', 'html'
+return {
+    "williamboman/mason.nvim",
+    dependencies = {
+        "williamboman/mason-lspconfig.nvim",
+        "neovim/nvim-lspconfig",
     },
-    on_new_config = function(config, new_root_dir)
-        -- The "workspaceFolder" is a VSCode concept. It limits how far the
-        -- server will traverse the file system when locating the ESLint config
-        -- file (e.g., .eslintrc).
+    config = function()
+        local mason = require("npx.mason-setup")
 
-        config.settings.workspaceFolder = {
-            uri = vim.loop.cwd(),
-            name = vim.fn.fnamemodify(new_root_dir, ":t")
-        }
-    end
-})
-
-mason.configure("theme_check", {root_dir = function() return vim.loop.cwd() end})
-
-mason.configure("angularls", {
-    on_attach = function(client)
-        vim.cmd [[compiler angular]]
-        client.server_capabilities.renameProvider = false
-    end
-})
-
--- TypeScript
-local init_options = require("nvim-lsp-ts-utils").init_options;
-init_options['preferences']['organizeImportsIgnoreCase'] = true;
-init_options['preferences']['importModuleSpecifierPreference'] = "relative";
-
-mason.configure("tsserver", {
-    capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol
-                                                                    .make_client_capabilities()),
-    -- Needed for inlayHints. Merge this table with your settings or copy
-    -- it from the source if you want to add your own init_options.
-    init_options = init_options,
-    --
-    on_attach = function(client, bufnr)
-        local ts_utils = require("nvim-lsp-ts-utils")
-
-        -- defaults
-        ts_utils.setup({
-            debug = false,
-            disable_commands = false,
-            enable_import_on_completion = true,
-            -- import all
-            import_all_timeout = 5000, -- ms
-            -- lower numbers = higher priority
-            import_all_priorities = {
-                same_file = 1, -- add to existing import statement
-                local_files = 2, -- git files or files with relative path markers
-                buffer_content = 3, -- loaded buffer content
-                buffers = 4 -- loaded buffer names
-            },
-            import_all_scan_buffers = 100,
-            import_all_select_source = false,
-            -- if false will avoid organizing imports
-            always_organize_imports = true,
-            -- filter diagnostics
-            filter_out_diagnostics_by_severity = {},
-            filter_out_diagnostics_by_code = {},
-            -- inlay hints
-            auto_inlay_hints = false,
-            inlay_hints_highlight = "Comment",
-            inlay_hints_priority = 200, -- priority of the hint extmarks
-            inlay_hints_throttle = 150, -- throttle the inlay hint request
-            inlay_hints_format = {
-                -- format options for individual hint kind
-                Type = {},
-                Parameter = {},
-                Enum = {}
-                -- Example format customization for `Type` kind:
-                -- Type = {
-                --     highlight = "Comment",
-                --     text = function(text)
-                --         return "->" .. text:sub(2)
-                --     end,
-                -- },
-            },
-            -- update imports on file move
-            update_imports_on_move = false,
-            require_confirmation_on_move = false,
-            watch_dir = nil
+        mason.configure("pylsp", {
+            settings = {
+                pylsp = {
+                    plugins = {
+                        pycodestyle = {ignore = {}, maxLineLength = 100},
+                        rope_autoimport = {enabled = true},
+                        rope_completion = {enabled = true}
+                    }
+                }
+            }
         })
 
-        -- required to fix code action ranges and filter diagnostics
-        ts_utils.setup_client(client)
+        -- borders for hover
+        vim.lsp.handlers["textDocument/hover"] =
+            vim.lsp.with(vim.lsp.handlers.hover, {border = "rounded"})
 
-        -- no default maps, so you may want to define some here
-        local opts = {silent = true}
-        vim.api
-            .nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", opts)
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>",
-                                    opts)
-        vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>",
-                                    opts)
+        -- ESLint
+        mason.configure("eslint", {
+            filetypes = {
+                'javascript', 'javascriptreact', 'javascript.jsx', 'typescript',
+                'typescriptreact', 'typescript.tsx', 'vue', 'svelte', 'astro', 'html'
+            },
+            on_new_config = function(config, new_root_dir)
+                -- The "workspaceFolder" is a VSCode concept. It limits how far the
+                -- server will traverse the file system when locating the ESLint config
+                -- file (e.g., .eslintrc).
+
+                config.settings.workspaceFolder = {
+                    uri = vim.loop.cwd(),
+                    name = vim.fn.fnamemodify(new_root_dir, ":t")
+                }
+            end
+        })
+
+        mason.configure("theme_check", {root_dir = function() return vim.loop.cwd() end})
+
+        mason.configure("angularls", {
+            on_attach = function(client)
+                vim.cmd [[compiler angular]]
+                client.server_capabilities.renameProvider = false
+            end
+        })
+
+        -- TypeScript
+        local init_options = require("nvim-lsp-ts-utils").init_options;
+        init_options['preferences']['organizeImportsIgnoreCase'] = true;
+        init_options['preferences']['importModuleSpecifierPreference'] = "relative";
+
+        mason.configure("tsserver", {
+            capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol
+                                                                        .make_client_capabilities()),
+            -- Needed for inlayHints. Merge this table with your settings or copy
+            -- it from the source if you want to add your own init_options.
+            init_options = init_options,
+            --
+            on_attach = function(client, bufnr)
+                local ts_utils = require("nvim-lsp-ts-utils")
+
+                -- defaults
+                ts_utils.setup({
+                    debug = false,
+                    disable_commands = false,
+                    enable_import_on_completion = true,
+                    -- import all
+                    import_all_timeout = 5000, -- ms
+                    -- lower numbers = higher priority
+                    import_all_priorities = {
+                        same_file = 1, -- add to existing import statement
+                        local_files = 2, -- git files or files with relative path markers
+                        buffer_content = 3, -- loaded buffer content
+                        buffers = 4 -- loaded buffer names
+                    },
+                    import_all_scan_buffers = 100,
+                    import_all_select_source = false,
+                    -- if false will avoid organizing imports
+                    always_organize_imports = true,
+                    -- filter diagnostics
+                    filter_out_diagnostics_by_severity = {},
+                    filter_out_diagnostics_by_code = {},
+                    -- inlay hints
+                    auto_inlay_hints = false,
+                    inlay_hints_highlight = "Comment",
+                    inlay_hints_priority = 200, -- priority of the hint extmarks
+                    inlay_hints_throttle = 150, -- throttle the inlay hint request
+                    inlay_hints_format = {
+                        -- format options for individual hint kind
+                        Type = {},
+                        Parameter = {},
+                        Enum = {}
+                        -- Example format customization for `Type` kind:
+                        -- Type = {
+                        --     highlight = "Comment",
+                        --     text = function(text)
+                        --         return "->" .. text:sub(2)
+                        --     end,
+                        -- },
+                    },
+                    -- update imports on file move
+                    update_imports_on_move = false,
+                    require_confirmation_on_move = false,
+                    watch_dir = nil
+                })
+
+                -- required to fix code action ranges and filter diagnostics
+                ts_utils.setup_client(client)
+
+                -- no default maps, so you may want to define some here
+                local opts = {silent = true}
+                vim.api
+                    .nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", opts)
+                vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>",
+                                            opts)
+                vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>",
+                                            opts)
+            end
+        })
+
+        -- C# (Omnisharp)
+        local pid = vim.fn.getpid()
+        local omnisharp_bin = "/Users/ybaron/omnisharp/run"
+        mason.configure("omnisharp", {
+            cmd = {omnisharp_bin, "--languageserver", "--hostPID", tostring(pid)},
+            root_dir = require("lspconfig").util.root_pattern("*.csproj", "*.sln"),
+            capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol
+                                                                        .make_client_capabilities())
+        })
+
+        -- Lua
+        mason.configure("lua_ls",
+                        {settings = {Lua = {diagnostics = {globals = {"vim"}}}}})
+
+        -- auto setup the rest
+        mason.setup()
     end
-})
-
--- C# (Omnisharp)
-local pid = vim.fn.getpid()
-local omnisharp_bin = "/Users/ybaron/omnisharp/run"
-mason.configure("omnisharp", {
-    cmd = {omnisharp_bin, "--languageserver", "--hostPID", tostring(pid)},
-    root_dir = require("lspconfig").util.root_pattern("*.csproj", "*.sln"),
-    capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol
-                                                                    .make_client_capabilities())
-})
-
--- Lua
-mason.configure("lua_ls",
-                {settings = {Lua = {diagnostics = {globals = {"vim"}}}}})
-
--- auto setup the rest
-mason.setup()
+}

--- a/nvim/.config/nvim/lua/npx/statusline.lua
+++ b/nvim/.config/nvim/lua/npx/statusline.lua
@@ -1,39 +1,44 @@
-local tracked_buffers = require("npx.buffer-management").tracked_buffers_lualine
+return {
+    "nvim-lualine/lualine.nvim",
+    dependencies = { "npx.buffer-management" },
+    config = function()
+        local tracked_buffers = require("npx.buffer-management").tracked_buffers_lualine
 
-require("lualine").setup({
-    options = {
-        icons_enabled = true,
-        theme = 'everforest',
-        component_separators = {left = '', right = ''},
-        section_separators = {left = '', right = ''},
-        disabled_filetypes = {statusline = {'qf'}, winbar = {}},
-        ignore_focus = {'qf'}, -- TODO check this option
-        always_divide_middle = true,
-        globalstatus = true,
-        refresh = {statusline = 200, tabline = 1000, winbar = 1000}
-    },
-    sections = {
-        lualine_a = {'mode'},
-        lualine_b = {tracked_buffers},
-        lualine_c = {},
-        lualine_x = {},
-        lualine_y = {},
-        lualine_z = {}
-    },
-    inactive_sections = {
-        lualine_a = {},
-        lualine_b = {},
-        lualine_c = {'filename'},
-        lualine_x = {'location'},
-        lualine_y = {},
-        lualine_z = {}
-    },
-    tabline = {
-        lualine_b = {'branch'},
-        lualine_c = {'filename'},
-        lualine_x = {},
-        lualine_y = {'filetype', 'fileformat'},
-        lualine_z = {'location'}
-    }
-})
-
+        require("lualine").setup({
+            options = {
+                icons_enabled = true,
+                theme = 'everforest',
+                component_separators = {left = '', right = ''},
+                section_separators = {left = '', right = ''},
+                disabled_filetypes = {statusline = {'qf'}, winbar = {}},
+                ignore_focus = {'qf'}, -- TODO check this option
+                always_divide_middle = true,
+                globalstatus = true,
+                refresh = {statusline = 200, tabline = 1000, winbar = 1000}
+            },
+            sections = {
+                lualine_a = {'mode'},
+                lualine_b = {tracked_buffers},
+                lualine_c = {},
+                lualine_x = {},
+                lualine_y = {},
+                lualine_z = {}
+            },
+            inactive_sections = {
+                lualine_a = {},
+                lualine_b = {},
+                lualine_c = {'filename'},
+                lualine_x = {'location'},
+                lualine_y = {},
+                lualine_z = {}
+            },
+            tabline = {
+                lualine_b = {'branch'},
+                lualine_c = {'filename'},
+                lualine_x = {},
+                lualine_y = {'filetype', 'fileformat'},
+                lualine_z = {'location'}
+            }
+        })
+    end
+}

--- a/nvim/.config/nvim/lua/npx/surround.lua
+++ b/nvim/.config/nvim/lua/npx/surround.lua
@@ -1,6 +1,10 @@
-require("nvim-surround").setup()
+return {
+    "kylechui/nvim-surround",
+    config = function()
+        require("nvim-surround").setup()
 
-vim.keymap.set("n", "<Leader>)", "ysiw)", {remap = true})
-vim.keymap.set("n", "<leader>]", "ysiw]", {remap = true})
-vim.keymap.set("n", "<leader>}", "ysiw}", {remap = true})
-
+        vim.keymap.set("n", "<Leader>)", "ysiw)", {remap = true})
+        vim.keymap.set("n", "<leader>]", "ysiw]", {remap = true})
+        vim.keymap.set("n", "<leader>}", "ysiw}", {remap = true})
+    end
+}

--- a/nvim/.config/nvim/lua/npx/telescope.lua
+++ b/nvim/.config/nvim/lua/npx/telescope.lua
@@ -1,46 +1,52 @@
-local telescope_builtin = require("telescope.builtin")
-local actions = require("telescope.actions")
+return {
+    "nvim-telescope/telescope.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    config = function()
+        local telescope_builtin = require("telescope.builtin")
+        local actions = require("telescope.actions")
 
-require("telescope").setup({
-    defaults = {
-        file_ignore_patterns = {
-            ".git/", "backendApi/", "backend/", -- make this load via exrc to project local
-            "apis/", -- make this load via exrc to project local
-            "%.mat", "%.meta", "%.asset", "%.prefab", "%.shader", "%.cginc",
-            "%.asmdef", "%.unity", "node_modules/", "projects/api/"
-        },
-        layout_strategy = "vertical",
-        mappings = {
-            i = {["<Tab>"] = "select_vertical", ["<esc>"] = actions.close},
-            n = {["<Tab>"] = "select_vertical"}
-        }
-    }
-})
+        require("telescope").setup({
+            defaults = {
+                file_ignore_patterns = {
+                    ".git/", "backendApi/", "backend/", -- make this load via exrc to project local
+                    "apis/", -- make this load via exrc to project local
+                    "%.mat", "%.meta", "%.asset", "%.prefab", "%.shader", "%.cginc",
+                    "%.asmdef", "%.unity", "node_modules/", "projects/api/"
+                },
+                layout_strategy = "vertical",
+                mappings = {
+                    i = {["<Tab>"] = "select_vertical", ["<esc>"] = actions.close},
+                    n = {["<Tab>"] = "select_vertical"}
+                }
+            }
+        })
 
-local M = {}
+        local M = {}
 
-M.project_files = function()
-    local opts = {use_git_root = false, show_untracked = true}
-    local ok = pcall(telescope_builtin.git_files, opts)
-    if not ok then telescope_builtin.find_files(opts) end
-end
-
-M.search_dotfiles = function()
-    telescope_builtin.git_files({
-        prompt_title = "< VimRC >",
-        cwd = vim.env.DOTFILES,
-        hidden = true
-    })
-end
-
-M.git_branches = function()
-    telescope_builtin.git_branches({
-        attach_mappings = function(_, map)
-            map("i", "<c-d>", actions.git_delete_branch)
-            map("n", "<c-d>", actions.git_delete_branch)
-            return true
+        M.project_files = function()
+            local opts = {use_git_root = false, show_untracked = true}
+            local ok = pcall(telescope_builtin.git_files, opts)
+            if not ok then telescope_builtin.find_files(opts) end
         end
-    })
-end
 
-return M
+        M.search_dotfiles = function()
+            telescope_builtin.git_files({
+                prompt_title = "< VimRC >",
+                cwd = vim.env.DOTFILES,
+                hidden = true
+            })
+        end
+
+        M.git_branches = function()
+            telescope_builtin.git_branches({
+                attach_mappings = function(_, map)
+                    map("i", "<c-d>", actions.git_delete_branch)
+                    map("n", "<c-d>", actions.git_delete_branch)
+                    return true
+                end
+            })
+        end
+
+        return M
+    end
+}

--- a/nvim/.config/nvim/lua/npx/treesitter.lua
+++ b/nvim/.config/nvim/lua/npx/treesitter.lua
@@ -1,1 +1,11 @@
-require'nvim-treesitter.configs'.setup {highlight = {enable = true}}
+return {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    config = function()
+        require'nvim-treesitter.configs'.setup {
+            highlight = {
+                enable = true
+            }
+        }
+    end
+}

--- a/nvim/.config/nvim/lua/npx/which-key.lua
+++ b/nvim/.config/nvim/lua/npx/which-key.lua
@@ -1,1 +1,6 @@
-require("which-key").setup()
+return {
+    "folke/which-key.nvim",
+    config = function()
+        require("which-key").setup()
+    end
+}


### PR DESCRIPTION
Convert plugin configurations in `nvim/.config/nvim/lua/npx` to lazy.vim while keeping each file separate.

* **Add lazy.vim setup:**
  - Add `nvim/.config/nvim/lua/npx/lazyvim.lua` to configure lazy.vim and require all plugin configuration files.
  - Modify `nvim/.config/nvim/lua/npx/init.lua` to require the `lazyvim` configuration.

* **Convert individual plugin configurations:**
  - Modify `nvim/.config/nvim/lua/npx/auto-complete.lua` to return a table with the `cmp` plugin configuration for lazy.vim.
  - Modify `nvim/.config/nvim/lua/npx/buffer-management.lua` to return a table with the buffer management configuration for lazy.vim.
  - Modify `nvim/.config/nvim/lua/npx/chatgpt.lua` to return a table with the `gp` plugin configuration for lazy.vim.
  - Modify `nvim/.config/nvim/lua/npx/comment.lua` to return a table with the `Comment` plugin configuration for lazy.vim.
  - Modify `nvim/.config/nvim/lua/npx/fterm.lua` to return a table with the `FTerm` plugin configuration for lazy.vim.
  - Modify `nvim/.config/nvim/lua/npx/lsp.lua` to return a table with the LSP plugin configuration for lazy.vim.

* **Update lazy.vim configuration:**
  - Add configuration for `cmp`, `buffer-management`, `gp`, `Comment`, `FTerm`, `lsp`, `lualine`, `nvim-surround`, `telescope`, `nvim-treesitter`, and `which-key` plugins in `nvim/.config/nvim/lua/npx/lazyvim.lua`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gingters/npx-.dotfiles/pull/2?shareId=637a448e-92c7-46df-8104-0e0c7739f68c).